### PR TITLE
Fix undefined global variable and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use your favoured plugin manager to install **bluz71/vim-moonfly-statusline**.
 
 If using [vim-plug](https://github.com/junegunn/vim-plug) do the following:
 
-1. Add `Plug bluz71/vim-moonfly-statusline'` to your *vimrc*
+1. Add `'Plug bluz71/vim-moonfly-statusline'` to your *vimrc*
 2. Run `:PlugInstall`
 
 License

--- a/plugin/moonfly.vim
+++ b/plugin/moonfly.vim
@@ -3,6 +3,8 @@
 " URL:          github.com/bluz71/vim-moonfly-statusline
 " License:      MIT (https://opensource.org/licenses/MIT)
 
+let g:normalMode = 0
+
 function! s:StatusLine(mode)
     if &buftype == "nofile" || bufname("%") == "[BufExplorer]"
         " Don't set a custom status line for file explorers.


### PR DESCRIPTION
This PR is created for fixing undefined some required variable of the plugin. I notice that variable `g:normalMode` isn't defined in this plugin. (but found in your `vimrc`)

Also fixed the README that missing single quote in installation section.