### PR TITLE
g:moonflyHonorUserDefinedColors for custom colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ If using [vim-plug](https://github.com/junegunn/vim-plug) do the following:
 Options
 -------
 
+### g:moonflyWithGitBranchCharacter
+
 The `g:moonflyWithGitBranchCharacter` option specifies whether to display Git
 branch details, via [vim-fugitive](https://github.com/tpope/vim-fugitive) if
 installed, using the Unicode Git branch character `U+E0A0`. By default Git
@@ -50,6 +52,27 @@ let g:moonflyWithGitBranchCharacter = 1
 ```
 
 The above screenshots are displayed with the Git branch character.
+
+### g:moonflyHonorUserDefinedColors
+
+The `g:g:moonflyHonorUserDefinedColors` option specifies whether user-defined
+colors should be used instead of the default colors from the moonfly scheme.
+
+```viml
+let g:moonflyHonorUserDefinedColors = 1
+```
+
+For example, these user-defined colors mimic Vim's default statusline colors:
+
+```viml
+highlight! link User1 StatusLine
+highlight! link User2 DiffAdd
+highlight! link User3 DiffChange
+highlight! link User4 DiffDelete
+highlight! link User5 StatusLine
+highlight! link User6 StatusLine
+highlight! link User7 StatusLine
+```
 
 License
 -------

--- a/plugin/moonfly.vim
+++ b/plugin/moonfly.vim
@@ -11,6 +11,9 @@ let g:loaded_moonfly_statusline = 1
 " By default don't display Git branches using the U+E0A0 branch character.
 let g:moonflyWithGitBranchCharacter = get(g:, "moonflyWithGitBranchCharacter", 0)
 
+" By default always use moonfly colors and ignore any user-defined colors.
+let g:moonflyHonorUserDefinedColors = get(g:, "moonflyHonorUserDefinedColors", 0)
+
 let s:modes = {
   \  "n":      ["%1*", " normal "],
   \  "i":      ["%2*", " insert "],
@@ -93,6 +96,9 @@ function! s:StatusLine(mode)
 endfunction
 
 function! s:UserColors()
+    if g:moonflyHonorUserDefinedColors
+        return
+    endif
     exec "highlight User1 ctermbg=4   guibg=" . s:blue    . " ctermfg=234 guifg=" . s:grey234
     exec "highlight User2 ctermbg=251 guibg=" . s:white   . " ctermfg=234 guifg=" . s:grey234
     exec "highlight User3 ctermbg=13  guibg=" . s:purple  . " ctermfg=234 guifg=" . s:grey234


### PR DESCRIPTION
This patch adds a new configuration option that lets the user specify
their own custom colors for the statusline in place of moonfly colors.