### PR TITLE
Add support for Signify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Plugins, Linters and Diagnostics supported
 
 - [GitGutter](https://github.com/airblade/vim-gitgutter)
 
+- [Signify](https://github.com/mhinz/vim-signify)
+
 - [Neovim Diagnostic](https://neovim.io/doc/user/diagnostic.html)
 
 - [ALE](https://github.com/dense-analysis/ale)
@@ -255,6 +257,7 @@ highlight! link MistflyReplace ErrorMsg
 | [mistflyWithGitBranch](https://github.com/bluz71/vim-mistfly-statusline#mistflywithgitbranch)                       | Enabled
 | [mistflyWithGitsignsStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithgitsignsstatus)             | Enabled if Gitsigns plugin is loaded
 | [mistflyWithGitGutterStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithgitgutterstatus)           | Enabled if GitGutter plugin is loaded
+| [mistflyWithSignifyStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithsignifystatus)               | Enabled if Signify plugin is loaded
 | [mistflyWithNvimDiagnosticStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithnvimdiagnosticstatus) | Enabled if nvim-lspconfig plugin is loaded
 | [mistflyWithALEStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithalestatus)                       | Enabled if ALE plugin is loaded
 | [mistflyWithCocStatus](https://github.com/bluz71/vim-mistfly-statusline#mistflywithcocstatus)                       | Enabled if Coc plugin is loaded
@@ -520,6 +523,29 @@ let g:mistflyWithGitGutterStatus = v:false
 ```lua
 -- Lua initialization file
 vim.g.mistflyWithGitGutterStatus = false
+```
+
+---
+
+### mistflyWithSignifyStatus
+
+The `mistflyWithSignifyStatus` option specifies whether to display
+[Signify](https://github.com/mhinz/vim-signify) status of the current
+buffer in the _statusline_.
+
+By default, Signify status will be displayed if the plugin is loaded.
+
+To disable the display of Signify status in the _statusline_ please add the
+following to your initialization file:
+
+```viml
+" Vimscript initialization file
+let g:mistflyWithSignifyStatus = v:false
+```
+
+```lua
+-- Lua initialization file
+vim.g.mistflyWithSignifyStatus = false
 ```
 
 ---

--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -101,14 +101,17 @@ function! mistfly#PluginsStatus() abort
     if g:mistflyWithGitsignsStatus && has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
         " Gitsigns status.
         let l:counts = get(b:, 'gitsigns_status_dict', {})
-        if has_key(l:counts, 'added') && l:counts['added'] > 0
-            let l:status .= ' %#MistflyGitAdd#+' . l:counts['added'] . '%*'
+        let l:added = get(l:counts, 'added', 0)
+        let l:changed = get(l:counts, 'changed', 0)
+        let l:removed = get(l:counts, 'removed', 0)
+        if l:added > 0
+            let l:status .= ' %#MistflyGitAdd#+' . l:added . '%*'
         endif
-        if has_key(l:counts, 'changed') && l:counts['changed'] > 0
-            let l:status .= ' %#MistflyGitChange#~' . l:counts['changed'] . '%*'
+        if l:changed > 0
+            let l:status .= ' %#MistflyGitChange#~' . l:changed . '%*'
         endif
-        if has_key(l:counts, 'removed') && l:counts['removed'] > 0
-            let l:status .= ' %#MistflyGitDelete#-' . l:counts['removed'] . '%*'
+        if l:removed > 0
+            let l:status .= ' %#MistflyGitDelete#-' . l:removed . '%*'
         endif
     elseif g:mistflyWithGitGutterStatus && exists('g:loaded_gitgutter')
         " GitGutter status.

--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -93,6 +93,9 @@ endfunction
 
 function! mistfly#PluginsStatus() abort
     let l:status = ''
+    let l:added = 0
+    let l:changed = 0
+    let l:removed = 0
     let l:errors = 0
     let l:warnings = 0
     let l:information = 0
@@ -104,39 +107,23 @@ function! mistfly#PluginsStatus() abort
         let l:added = get(l:counts, 'added', 0)
         let l:changed = get(l:counts, 'changed', 0)
         let l:removed = get(l:counts, 'removed', 0)
-        if l:added > 0
-            let l:status .= ' %#MistflyGitAdd#+' . l:added . '%*'
-        endif
-        if l:changed > 0
-            let l:status .= ' %#MistflyGitChange#~' . l:changed . '%*'
-        endif
-        if l:removed > 0
-            let l:status .= ' %#MistflyGitDelete#-' . l:removed . '%*'
-        endif
     elseif g:mistflyWithGitGutterStatus && exists('g:loaded_gitgutter')
         " GitGutter status.
-        let [added, changed, removed] = GitGutterGetHunkSummary()
-        if added > 0
-            let l:status .= ' %#MistflyGitAdd#+' . added . '%*'
-        endif
-        if changed > 0
-            let l:status .= ' %#MistflyGitChange#~' . changed . '%*'
-        endif
-        if removed > 0
-            let l:status .= ' %#MistflyGitDelete#-' . removed . '%*'
-        endif
+        let [l:added, l:changed, l:removed] = GitGutterGetHunkSummary()
     elseif g:mistflyWithSignifyStatus && exists('g:loaded_signify') && sy#buffer_is_active()
         " Signify status.
-        let [added, changed, removed] = sy#repo#get_stats()
-        if added > 0
-            let l:status .= ' %#MistflyGitAdd#+' . added . '%*'
-        endif
-        if changed > 0
-            let l:status .= ' %#MistflyGitChange#~' . changed . '%*'
-        endif
-        if removed > 0
-            let l:status .= ' %#MistflyGitDelete#-' . removed . '%*'
-        endif
+        let [l:added, l:changed, l:removed] = sy#repo#get_stats()
+    endif
+
+    " Git plugin status.
+    if l:added > 0
+        let l:status .= ' %#MistflyGitAdd#+' . l:added . '%*'
+    endif
+    if l:changed > 0
+        let l:status .= ' %#MistflyGitChange#~' . l:changed . '%*'
+    endif
+    if l:removed > 0
+        let l:status .= ' %#MistflyGitDelete#-' . l:removed . '%*'
     endif
     if len(l:status) > 0
         let l:status .= ' '

--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -112,10 +112,8 @@ function! mistfly#PluginsStatus() abort
                 let l:status .= ' %#MistflyGitDelete#-' . l:counts['removed'] . '%*'
             endif
         endif
-        if len(l:status) > 0
-            let l:status .= ' '
-        endif
     elseif g:mistflyWithGitGutterStatus && exists('g:loaded_gitgutter')
+        " GitGutter status.
         let [added, changed, removed] = GitGutterGetHunkSummary()
         if added > 0
             let l:status .= ' %#MistflyGitAdd#+' . added . '%*'
@@ -126,6 +124,21 @@ function! mistfly#PluginsStatus() abort
         if removed > 0
             let l:status .= ' %#MistflyGitDelete#-' . removed . '%*'
         endif
+    elseif g:mistflyWithSignifyStatus && exists('g:loaded_signify') && sy#buffer_is_active()
+        " Signify status.
+        let [added, changed, removed] = sy#repo#get_stats()
+        if added > 0
+            let l:status .= ' %#MistflyGitAdd#+' . added . '%*'
+        endif
+        if changed > 0
+            let l:status .= ' %#MistflyGitChange#~' . changed . '%*'
+        endif
+        if removed > 0
+            let l:status .= ' %#MistflyGitDelete#-' . removed . '%*'
+        endif
+    endif
+    if len(l:status) > 0
+        let l:status .= ' '
     endif
 
     if g:mistflyWithNvimDiagnosticStatus && exists('g:lspconfig')
@@ -468,6 +481,10 @@ function s:ColorSchemeGitHighlights() abort
         call s:SynthesizeHighlight('MistflyGitAdd', 'GitGutterAdd', v:false)
         call s:SynthesizeHighlight('MistflyGitChange', 'GitGutterChange', v:false)
         call s:SynthesizeHighlight('MistflyGitDelete', 'GitGutterDelete', v:false)
+    elseif hlexists('SignifySignAdd')
+        call s:SynthesizeHighlight('MistflyGitAdd', 'SignifySignAdd', v:false)
+        call s:SynthesizeHighlight('MistflyGitChange', 'SignifySignChange', v:false)
+        call s:SynthesizeHighlight('MistflyGitDelete', 'SignifySignDelete', v:false)
     elseif hlexists('diffAdded')
         call s:SynthesizeHighlight('MistflyGitAdd', 'diffAdded', v:false)
         call s:SynthesizeHighlight('MistflyGitChange', 'diffChanged', v:false)

--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -101,16 +101,14 @@ function! mistfly#PluginsStatus() abort
     if g:mistflyWithGitsignsStatus && has('nvim-0.5') && luaeval("pcall(require, 'gitsigns')")
         " Gitsigns status.
         let l:counts = get(b:, 'gitsigns_status_dict', {})
-        if has_key(l:counts, 'added')
-            if l:counts['added'] > 0
-                let l:status .= ' %#MistflyGitAdd#+' . l:counts['added'] . '%*'
-            endif
-            if l:counts['changed'] > 0
-                let l:status .= ' %#MistflyGitChange#~' . l:counts['changed'] . '%*'
-            endif
-            if l:counts['removed'] > 0
-                let l:status .= ' %#MistflyGitDelete#-' . l:counts['removed'] . '%*'
-            endif
+        if has_key(l:counts, 'added') && l:counts['added'] > 0
+            let l:status .= ' %#MistflyGitAdd#+' . l:counts['added'] . '%*'
+        endif
+        if has_key(l:counts, 'changed') && l:counts['changed'] > 0
+            let l:status .= ' %#MistflyGitChange#~' . l:counts['changed'] . '%*'
+        endif
+        if has_key(l:counts, 'removed') && l:counts['removed'] > 0
+            let l:status .= ' %#MistflyGitDelete#-' . l:counts['removed'] . '%*'
         endif
     elseif g:mistflyWithGitGutterStatus && exists('g:loaded_gitgutter')
         " GitGutter status.

--- a/plugin/mistfly-statusline.vim
+++ b/plugin/mistfly-statusline.vim
@@ -61,6 +61,9 @@ let g:mistflyWithGitsignsStatus = get(g:, 'mistflyWithGitsignsStatus', v:true)
 " By default display GitGutter status, if the plugin is loaded.
 let g:mistflyWithGitGutterStatus = get(g:, 'mistflyWithGitGutterStatus', v:true)
 
+" By default display Signify status, if the plugin is loaded.
+let g:mistflyWithSignifyStatus = get(g:, 'mistflyWithSignifyStatus', v:true)
+
 " By default don't display a filetype icon.
 let g:mistflyWithFileIcon = get(g:, 'mistflyWithFileIcon', v:false)
 


### PR DESCRIPTION
I realise a feature of this plugin is that its simple and fast, with a low code line count. That realised, this pull request squeezes in support for [Signify](https://github.com/mhinz/vim-signify).

The first commit adds that support.

The following three commits are refactoring, separated to show the idea behind each change. These can be squashed if the pull request is approved. The last commit, avoiding duplicate code, follows the same style that is used for errors, warnings and information (in the same function).