### PR TITLE
Prevent selecting GitGutter when its loaded but not enabled

### DIFF
--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -148,7 +148,7 @@ function! mistfly#PluginsStatus() abort
     elseif g:mistflyWithGitStatus && exists('g:loaded_gitgutter') && get(g:, 'gitgutter_enabled')
         " GitGutter status.
         let [l:added, l:changed, l:removed] = GitGutterGetHunkSummary()
-    elseif g:mistflyWithGitStatus && exists('g:loaded_signify') && sy#buffer_is_active()
+    elseif g:mistflyWithGitStatus && exists('g:loaded_signify')
         " Signify status.
         let [l:added, l:changed, l:removed] = sy#repo#get_stats()
     endif

--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -145,7 +145,7 @@ function! mistfly#PluginsStatus() abort
         let l:added = get(l:counts, 'added', 0)
         let l:changed = get(l:counts, 'changed', 0)
         let l:removed = get(l:counts, 'removed', 0)
-    elseif g:mistflyWithGitStatus && exists('g:loaded_gitgutter')
+    elseif g:mistflyWithGitStatus && exists('g:loaded_gitgutter') && get(g:, 'gitgutter_enabled')
         " GitGutter status.
         let [l:added, l:changed, l:removed] = GitGutterGetHunkSummary()
     elseif g:mistflyWithGitStatus && exists('g:loaded_signify') && sy#buffer_is_active()


### PR DESCRIPTION
When the following configuration:
- mistflyWithGitsignsStatus
- mistflyWithGitGutterStatus
- mistflyWithSignifyStatus

was replaced with:
- mistflyWithGitStatus

control was lost over selection of the Git status plugin.

That selecting ability was useful when a vim configuration has multiple Git status plugins loaded with only one enabled.

This pull request allows GitGutter to be loaded but not enabled, and Signify to be selected (if loaded and enabled).

The second commit removes the call to Signify buffer_is_active(). Please see commit message for details.