### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,9 @@ presence of the Diagnostics in the current buffer.
 [ALE](https://github.com/dense-analysis/ale) and
 [Coc](https://github.com/neoclide/coc.nvim) are supported.
 
+By default, Diagnostics will be displayed if one of the above plugins are
+loaded.
+
 If Diagnostic display is not wanted then please add the following to your
 initialization file:
 

--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ vim.g.mistflyActiveTabSymbol = '<<SYMBOL-OF-YOUR-CHOOSING>>'
 
 ### mistflyGitBranchSymbol
 
-The `mistflyGitBranchSymbol` option specifies which character symbol to use to
-signify the active tab in the `tabline`.
+The `mistflyGitBranchSymbol` option specifies which character symbol to use
+when displaying Git branch details.
 
 By default, the `` character (Powerline `U+E0A0`) will be displayed. Many
 modern monospace fonts will contain that character.
@@ -448,8 +448,9 @@ Note, Neovim 0.8 (or later) is required for this feature.
 
 Displaying a window bar is recommended when Neovim's global statusline is
 enabled via `set laststatus=3`; the `winbar` will then display the file name at
-the top of each window to disambiguate splits. Also, if there only one window in
-the current tab then a `winbar` will not be displayed (it won't be needed).
+the top of each window to disambiguate splits. Also, if there is only one
+window in the current tab then a `winbar` will not be displayed (it won't be
+needed).
 
 To enable Neovim's `winbar` feature please add the following to your
 initialization file:
@@ -544,10 +545,10 @@ vim.g.mistflyWithGitStatus = false
 
 ### mistflyWithDiagnosticStatus
 
-The `mistflyWithNvimDiagnosticStatus` option specifies whether to indicate the
+The `mistflyWithDiagnosticStatus` option specifies whether to indicate the
 presence of the Diagnostics in the current buffer.
 
-[Neovim Diagnositics](https://neovim.io/doc/user/diagnostic.html)
+[Neovim Diagnositics](https://neovim.io/doc/user/diagnostic.html),
 [ALE](https://github.com/dense-analysis/ale) and
 [Coc](https://github.com/neoclide/coc.nvim) are supported.
 
@@ -592,7 +593,7 @@ vim.g.mistflyWithSessionStatus = false
 ### mistflyWithIndentStatus
 
 The `mistflyWithIndentStatus` option specifies whether to display the
-indentation status as the last component in the statusline. By default
+indentation status as the last component in the `statusline`. By default
 indentation status will not be displayed.
 
 Note, if the `expandtab` option is set, for the current buffer, then tab stop

--- a/doc/mistfly.txt
+++ b/doc/mistfly.txt
@@ -74,8 +74,8 @@ initialization file:
 ------------------------------------------------------------------------------
 mistflyGitBranchSymbol~                             *g:mistflyGitBranchSymbol*
 
-The `mistflyGitBranchSymbol` option specifies which character symbol to use to
-signify the active tab in the `tabline`.
+The `mistflyGitBranchSymbol` option specifies which character symbol to use
+when displaying Git branch details
 
 By default, the `` character (Powerline `U+E0A0`) will be displayed. Many
 modern monospace fonts will contain that character.
@@ -172,8 +172,9 @@ Note, Neovim 0.8 (or later) is required for this feature.
 
 Displaying a window bar is recommended when Neovim's global statusline is
 enabled via `set laststatus=3`; the `winbar` will then display the file name at
-the top of each window to disambiguate splits. Also, if there only one window in
-the current tab then a `winbar` will not be displayed (it won't be needed).
+the top of each window to disambiguate splits. Also, if there is only one
+window in the current tab then a `winbar` will not be displayed (it won't be
+needed).
 
 To enable Neovim's `winbar` feature please add the following to your
 initialization file:
@@ -252,10 +253,10 @@ following to your initialization file:
 ------------------------------------------------------------------------------
 mistflyWithDiagnosticStatus~                   *g:mistflyWithDiagnosticStatus*
 
-The `mistflyWithNvimDiagnosticStatus` option specifies whether to indicate the
+The `mistflyWithDiagnosticStatus` option specifies whether to indicate the
 presence of the Diagnostics in the current buffer.
 
-Neovim Diagnositics (https://neovim.io/doc/user/diagnostic.html) ALE
+Neovim Diagnositics (https://neovim.io/doc/user/diagnostic.html), ALE
 (https://github.com/dense-analysis/ale) and Coc
 (https://github.com/neoclide/coc.nvim) are supported.
 
@@ -291,7 +292,7 @@ following to your initialization file:
 mistflyWithIndentStatus~                           *g:mistflyWithIndentStatus*
 
 The `mistflyWithIndentStatus` option specifies whether to display the
-indentation status as the last component in the statusline. By default
+indentation status as the last component in the `statusline`. By default
 indentation status will not be displayed.
 
 Note, if the `expandtab` option is set, for the current buffer, then tab stop

--- a/doc/mistfly.txt
+++ b/doc/mistfly.txt
@@ -260,6 +260,9 @@ Neovim Diagnositics (https://neovim.io/doc/user/diagnostic.html), ALE
 (https://github.com/dense-analysis/ale) and Coc
 (https://github.com/neoclide/coc.nvim) are supported.
 
+By default, Diagnostics will be displayed if one of the above plugins are
+loaded.
+
 If Diagnostic display is not wanted then please add the following to your
 initialization file:
 

--- a/doc/mistfly.txt
+++ b/doc/mistfly.txt
@@ -30,6 +30,7 @@ By default, the `⎪` character (Unicode `U+23AA`) will be displayed.
 
 To specify your own separator symbol please add the following to your
 initialization file:
+
 >
   " Vimscript initialization file
   let g:mistflySeparatorSymbol = '<<SYMBOL-OF-YOUR-CHOOSING>>'
@@ -47,6 +48,7 @@ By default, the `↓` character (Unicode `U+2193`) will be displayed.
 
 To specify your own progress symbol, or no symbol at all, please add the
 following to your initialization file:
+
 >
   " Vimscript initialization file
   let g:mistflyProgressSymbol = '<<SYMBOL-OF-YOUR-CHOOSING-OR-EMPTY>>'
@@ -64,6 +66,7 @@ By default, the `▪` character (Unicode `U+25AA`) will be displayed.
 
 To specify your own active tab symbol please add the following to your
 initialization file:
+
 >
   " Vimscript initialization file
   let g:mistflyActiveTabSymbol = '<<SYMBOL-OF-YOUR-CHOOSING>>'
@@ -82,6 +85,7 @@ modern monospace fonts will contain that character.
 
 To specify your own Git Branch symbol, or no symbol at all, please add the
 following to your initialization file:
+
 >
   " Vimscript initialization file
   let g:mistflyGitBranchSymbol = '<<SYMBOL-OF-YOUR-CHOOSING-OR-EMPTY>>'
@@ -99,6 +103,7 @@ By default, the `E` character, will be displayed.
 
 To specify your own error symbol please add the following to your initialization
 file:
+
 >
   " Vimscript initialization file
   let g:mistflyErrorSymbol = '<<SYMBOL-OF-YOUR-CHOOSING>>'
@@ -116,6 +121,7 @@ By default, the `W` character, will be displayed.
 
 To specify your own warning symbol please add the following to your
 initialization file:
+
 >
   " Vimscript initialization file
   let g:mistflyWarningSymbol = '<<SYMBOL-OF-YOUR-CHOOSING>>'
@@ -159,6 +165,7 @@ file:
 >
   " Vimscript initialization file
   let g:mistflyTabLine = v:true
+
   -- Lua initialization file
   vim.g.mistflyTabLine = true
 <

--- a/doc/mistfly.txt
+++ b/doc/mistfly.txt
@@ -1,6 +1,6 @@
 *mistfly* A simple, fast and informative statusline for Vim and (legacy) Neovim
 
-OPTIONS                                                       *mistfly-options*
+OPTIONS                                                      *mistfly-options*
 
 Default option values:
 >


### PR DESCRIPTION
There are four commits in this pull request.

The first contains minor fixes. Please see commit message for details.

The second adds `By default` details for the only option where this was omitted.

The third makes vertical whitespace consistent. Initially I removed the additional blank lines, however then realised that there were more sections with the blank line than not.

The fourth makes the first section heading 78 characters wide (i.e., the document's text width). I noted the title is 79 characters, however I guess that should be a one liner.

Please let me know if any commits need changing.