### PR TITLE
Fix only showing search count when hlsearch is on

### DIFF
--- a/autoload/mistfly.vim
+++ b/autoload/mistfly.vim
@@ -294,7 +294,7 @@ function! mistfly#ActiveStatusLine() abort
         endif
     endif
     let l:statusline .= '%='
-    if g:mistflyWithSearchCount && &hlsearch
+    if g:mistflyWithSearchCount && &hlsearch && v:hlsearch
         let l:search_count = mistfly#SearchCount()
         if len(l:search_count) > 0
             let l:statusline .= l:search_count . ' ' . l:separator . ' '


### PR DESCRIPTION
This issue is due to replacing `v:hlsearch` with `&hlsearch` in commit 460f2fa5ca771eab2601701ecd0be091dbffc534.

In the change here, both `&hlsearch` and `v:hlsearch` are used. Although I'm not exactly sure if `&hlsearch` is needed; it may serve as a safe guard.